### PR TITLE
Fix authentication (useful for private repos)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -76,9 +76,6 @@ $(document).ready(function () {
     $.ajax({
       type: 'GET',
       url: 'https://api.github.com/repos/' + username + '/' + repo + '/labels',
-      beforeSend: function(xhr) {
-        loadingSemaphore.acquire();
-      },
       success: function (response) {
         console.log("success: ");
         console.log(response);


### PR DESCRIPTION
The `beforeSend`-callback is already implemented globally using `$.ajaxSetup()` (line 60-64). Overriding the callback causes the global callback no longer being executed.

The call to `loadingSemaphore.acquire()` is also part of the global callback anyway.

Fixes #3.

---

Note: the GitHub web editor added a line feed to the end of the file. JavaScript files should end with a newline anyway so I'm keeping this. (Read [here](https://evanhahn.com/newline-necessary-at-the-end-of-javascript-files/) or [here](https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline).)